### PR TITLE
Swaps dash for underscore in package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redash_toolbelt"
-version = "0.1.0"
+version = "0.1.1"
 description = "Redash API client and tools to manage your instance."
 authors = ["Redash Maintainers"]
 license = "BSD-2-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "redash-toolbelt"
+name = "redash_toolbelt"
 version = "0.1.0"
 description = "Redash API client and tools to manage your instance."
 authors = ["Redash Maintainers"]


### PR DESCRIPTION
Finishes the work of 7341f779. The package name must also use an underscore, otherwise import fails.