### PR TITLE
Fixes dashboard_refresh.py

### DIFF
--- a/redash_toolbelt/examples/refresh_dashboard.py
+++ b/redash_toolbelt/examples/refresh_dashboard.py
@@ -4,7 +4,6 @@ from redash_toolbelt import Redash, get_frontend_vals
 
 def refresh_dashboard(baseurl, apikey, slug):
 
-    # build a client, fetch the dashboard, and calculate todays dates
     client = Redash(baseurl, apikey)
     todays_dates = get_frontend_vals()
     queries_dict = get_queries_on_dashboard(client, slug)
@@ -17,9 +16,9 @@ def refresh_dashboard(baseurl, apikey, slug):
             for p in qry["options"].get("parameters", [])
         }
 
+        # Pass max_age to ensure a new result is provided.
         request_json = {"parameters": params, "max_age": 0}
 
-        # Pass max_age to ensure a new result is provided.
         r = client._post(f"api/queries/{idx}/results", json=request_json)
 
         print(f"Query: {idx} -- Code {r.status_code}")

--- a/redash_toolbelt/examples/refresh_dashboard.py
+++ b/redash_toolbelt/examples/refresh_dashboard.py
@@ -9,7 +9,7 @@ def refresh_dashboard(baseurl, apikey, slug):
     todays_dates = get_frontend_vals()
     queries_dict = get_queries_on_dashboard(client, slug)
 
-    # loop through each query and it's JSON data
+    # loop through each query and its JSON data
     for idx, qry in queries_dict.items():
 
         params = {}
@@ -49,8 +49,12 @@ def query_has_parameters(query_details):
 
 
 def fill_dynamic_val(dates, p):
-    """Returns the appropriate dynamic date parameter value.
-	If the input is not a valid dynamic parameter it is returned unchanged.
+    """Accepts parameter default information from the Redash API.
+
+    If the default value is not a date type, or its value cannot be calculated,
+    then the default value is returned unchanged.
+
+	Otherwise, the dynamic value is retrieved from the dates param and returned
 	"""
 
     if not is_dynamic_param(dates, p):

--- a/redash_toolbelt/examples/refresh_dashboard.py
+++ b/redash_toolbelt/examples/refresh_dashboard.py
@@ -3,92 +3,93 @@ from redash_toolbelt import Redash, get_frontend_vals
 
 
 def refresh_dashboard(baseurl, apikey, slug):
-	
-	# build a client, fetch the dashboard, and calculate todays dates
-	client = Redash(baseurl, apikey)
-	todays_dates = get_frontend_vals()
-	queries_dict = get_queries_on_dashboard(client, slug)
 
-	# idx is the query ID. qry is the JSON data about that query ID.
-	for idx, qry in queries_dict.items():
+    # build a client, fetch the dashboard, and calculate todays dates
+    client = Redash(baseurl, apikey)
+    todays_dates = get_frontend_vals()
+    queries_dict = get_queries_on_dashboard(client, slug)
 
-		if query_has_parameters(qry):
-			params = {key: fill_dynamic_val(todays_dates, val)
-				for key, val in iter_params(qry)}
-		else:
-			params = {}
+    # idx is the query ID. qry is the JSON data about that query ID.
+    for idx, qry in queries_dict.items():
 
-		# Pass max_age to ensure a new result is provided.
-		r = client._post(f"api/queries/{idx}/results",
-			json={'parameters': params, "max_age": 0} )
-		
-		print(f"Query: {idx} -- Code {r.status_code}")
+        if query_has_parameters(qry):
+            params = {
+                key: fill_dynamic_val(todays_dates, val)
+                for key, val in iter_params(qry)
+            }
+        else:
+            params = {}
+
+        request_json = {"parameters": params, "max_age": 0}
+
+        # Pass max_age to ensure a new result is provided.
+        r = client._post(f"api/queries/{idx}/results", json=request_json)
+
+        print(f"Query: {idx} -- Code {r.status_code}")
 
 
 def get_queries_on_dashboard(client, slug):
 
-	# Get a list of queries on this dashboard
-	dash = client.dashboard(slug=slug)
+    # Get a list of queries on this dashboard
+    dash = client.dashboard(slug=slug)
 
-	# Dashboards have visualization and text box widgets. Get the viz widgets.
-	viz_widgets = [i for i in dash['widgets'] if 'visualization' in i.keys()]
+    # Dashboards have visualization and text box widgets. Get the viz widgets.
+    viz_widgets = [i for i in dash["widgets"] if "visualization" in i.keys()]
 
-	# Visualizations are tied to queries
-	l_query_ids = [i['visualization']['query']['id'] for i in viz_widgets]
+    # Visualizations are tied to queries
+    l_query_ids = [i["visualization"]["query"]["id"] for i in viz_widgets]
 
-	return {id: client._get(f'api/queries/{id}').json() for id in l_query_ids}
+    return {id: client._get(f"api/queries/{id}").json() for id in l_query_ids}
 
 
 def query_has_parameters(query_details):
 
-	params = query_details['options'].get('parameters', None)
-	return params is not None and len(params) > 0
+    params = query_details["options"].get("parameters", None)
+    return params is not None and len(params) > 0
 
 
 def fill_dynamic_val(dates, val):
-	'''Returns the appropriate dynamic date parameter value.
+    """Returns the appropriate dynamic date parameter value.
 	If the input is not a valid dynamic parameter it is returned unchanged.
-	'''
+	"""
 
-	if val not in dates._fields:
-		return val
+    if val not in dates._fields:
+        return val
 
-	new_val = getattr(dates, val)
+    new_val = getattr(dates, val)
 
-	if not is_date_range(new_val):
-		return format_date(new_val)
+    if not is_date_range(new_val):
+        return format_date(new_val)
 
-	else:
-		return dict(start=format_date(new_val.start),
-			end=format_date(new_val.end))
+    return {"start": format_date(new_val.start), "end": format_date(new_val.end)}
 
 
 def is_date_range(value):
-	return hasattr(value, 'start') and hasattr(value, 'end')
+    return hasattr(value, "start") and hasattr(value, "end")
 
 
 def format_date(date_obj):
-	return date_obj.strftime('%Y-%m-%d')
+    return date_obj.strftime("%Y-%m-%d")
 
 
 def iter_params(query_object):
-	"""Returns an iterator of parameter name-value pairs
+    """Returns an iterator of parameter name-value pairs
 	from an API query object"""
 
-	return {i.get('name'): i.get('value')
-		for i in query_object['options']['parameters']}.items()
-
+    return {
+        i.get("name"): i.get("value") for i in query_object["options"]["parameters"]
+    }.items()
 
 
 @click.command()
-@click.argument('url',)
-@click.argument('key',)
-@click.argument('slug',)
+@click.argument("url",)
+@click.argument("key",)
+@click.argument("slug",)
 def main(url, key, slug):
-	"""Refresh URL/dashboards/SLUG using KEY"""
+    """Refresh URL/dashboards/SLUG using KEY"""
 
-	refresh_dashboard(url, key, slug)
+    refresh_dashboard(url, key, slug)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/redash_toolbelt/examples/refresh_dashboard.py
+++ b/redash_toolbelt/examples/refresh_dashboard.py
@@ -16,8 +16,8 @@ def refresh_dashboard(baseurl, apikey, slug):
 
         if query_has_parameters(qry):
             params = {
-                key: fill_dynamic_val(todays_dates, val)
-                for key, val in iter_params(qry)
+                p.get("name"): fill_dynamic_val(todays_dates, p)
+                for p in qry["options"]["parameters"]
             }
 
         request_json = {"parameters": params, "max_age": 0}
@@ -48,20 +48,24 @@ def query_has_parameters(query_details):
     return params is not None and len(params) > 0
 
 
-def fill_dynamic_val(dates, val):
+def fill_dynamic_val(dates, p):
     """Returns the appropriate dynamic date parameter value.
 	If the input is not a valid dynamic parameter it is returned unchanged.
 	"""
 
-    if val not in dates._fields:
-        return val
+    if not is_dynamic_param(dates, p):
+        return p.get("value")
+    dyn_val = getattr(dates, p.get("value"))
 
-    new_val = getattr(dates, val)
-
-    if is_date_range(new_val):
-        return format_date_range(new_val)
+    if is_date_range(dyn_val):
+        return format_date_range(dyn_val)
     else:
-        return format_date(new_val)
+        return format_date(dyn_val)
+
+
+def is_dynamic_param(dates, param):
+
+    return "date" in param.get("type") and param.get("value") in dates._fields
 
 
 def is_date_range(value):

--- a/redash_toolbelt/examples/refresh_dashboard.py
+++ b/redash_toolbelt/examples/refresh_dashboard.py
@@ -17,9 +17,9 @@ def refresh_dashboard(baseurl, apikey, slug):
         }
 
         # Pass max_age to ensure a new result is provided.
-        request_json = {"parameters": params, "max_age": 0}
+        body = {"parameters": params, "max_age": 0}
 
-        r = client._post(f"api/queries/{idx}/results", json=request_json)
+        r = client._post(f"api/queries/{idx}/results", json=body)
 
         print(f"Query: {idx} -- Code {r.status_code}")
 

--- a/redash_toolbelt/examples/refresh_dashboard.py
+++ b/redash_toolbelt/examples/refresh_dashboard.py
@@ -12,13 +12,10 @@ def refresh_dashboard(baseurl, apikey, slug):
     # loop through each query and its JSON data
     for idx, qry in queries_dict.items():
 
-        params = {}
-
-        if query_has_parameters(qry):
-            params = {
-                p.get("name"): fill_dynamic_val(todays_dates, p)
-                for p in qry["options"]["parameters"]
-            }
+        params = {
+            p.get("name"): fill_dynamic_val(todays_dates, p)
+            for p in qry["options"].get("parameters", [])
+        }
 
         request_json = {"parameters": params, "max_age": 0}
 

--- a/redash_toolbelt/examples/refresh_dashboard.py
+++ b/redash_toolbelt/examples/refresh_dashboard.py
@@ -9,16 +9,16 @@ def refresh_dashboard(baseurl, apikey, slug):
     todays_dates = get_frontend_vals()
     queries_dict = get_queries_on_dashboard(client, slug)
 
-    # idx is the query ID. qry is the JSON data about that query ID.
+    # loop through each query and it's JSON data
     for idx, qry in queries_dict.items():
+
+        params = {}
 
         if query_has_parameters(qry):
             params = {
                 key: fill_dynamic_val(todays_dates, val)
                 for key, val in iter_params(qry)
             }
-        else:
-            params = {}
 
         request_json = {"parameters": params, "max_age": 0}
 
@@ -58,10 +58,10 @@ def fill_dynamic_val(dates, val):
 
     new_val = getattr(dates, val)
 
-    if not is_date_range(new_val):
+    if is_date_range(new_val):
+        return format_date_range(new_val)
+    else:
         return format_date(new_val)
-
-    return {"start": format_date(new_val.start), "end": format_date(new_val.end)}
 
 
 def is_date_range(value):
@@ -70,6 +70,14 @@ def is_date_range(value):
 
 def format_date(date_obj):
     return date_obj.strftime("%Y-%m-%d")
+
+
+def format_date_range(date_range_obj):
+
+    start = format_date(date_range_obj.start)
+    end = format_date(date_range_obj.end)
+
+    return dict(start=start, end=end)
 
 
 def iter_params(query_object):

--- a/redash_toolbelt/examples/refresh_dashboard.py
+++ b/redash_toolbelt/examples/refresh_dashboard.py
@@ -42,8 +42,11 @@ for q in [i for i in l_query_info if 'parameters' in i['options']]:
 
 		# Case: the date parameter is dynamic.
 		if v in dd._fields:
-			flat_params[f"{k}.start"] = getattr(dd, v).start.strftime('%Y-%m-%d')
-			flat_params[f"{k}.end"] = getattr(dd, v).end.strftime('%Y-%m-%d')
+			try:
+				flat_params[f"{k}.start"] = getattr(dd, v).start.strftime('%Y-%m-%d')
+				flat_params[f"{k}.end"] = getattr(dd, v).end.strftime('%Y-%m-%d')
+			except:
+				flat_params[k] = getattr(dd,v).strftime('%Y-%m-%d')
 
 		# Case: the date parameter is a hardcoded dictionary with 'start' and 'end' keys
 		elif isinstance(v, dict):

--- a/redash_toolbelt/examples/refresh_dashboard.py
+++ b/redash_toolbelt/examples/refresh_dashboard.py
@@ -38,12 +38,6 @@ def get_queries_on_dashboard(client, slug):
     return {id: client._get(f"api/queries/{id}").json() for id in l_query_ids}
 
 
-def query_has_parameters(query_details):
-
-    params = query_details["options"].get("parameters", None)
-    return params is not None and len(params) > 0
-
-
 def fill_dynamic_val(dates, p):
     """Accepts parameter default information from the Redash API.
 

--- a/redash_toolbelt/examples/refresh_dashboard.py
+++ b/redash_toolbelt/examples/refresh_dashboard.py
@@ -84,15 +84,6 @@ def format_date_range(date_range_obj):
     return dict(start=start, end=end)
 
 
-def iter_params(query_object):
-    """Returns an iterator of parameter name-value pairs
-	from an API query object"""
-
-    return {
-        i.get("name"): i.get("value") for i in query_object["options"]["parameters"]
-    }.items()
-
-
 @click.command()
 @click.argument("url",)
 @click.argument("key",)


### PR DESCRIPTION
This PR fixes a few issues with `dashboard_refresh.py`:

+ The code is much easier to read. Smaller functions and all
+ It uses the `/api/queries/<id>/results` endpoint instead of `/api/queries/<id>/refresh`. The latter will be deprecated eventually
+ Fixes a bug where refresh would fail for queries with dynamic dates (not date ranges)