### PR TITLE
Add GDPR script to examples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ click = "^7.0"
 
 [tool.poetry.dev-dependencies]
 
+[tool.poetry.scripts]
+gdpr-scrub = "redash_toolbelt.examples.gdpr_scrub:lookup"
+
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/redash_toolbelt/examples/gdpr_scrub.py
+++ b/redash_toolbelt/examples/gdpr_scrub.py
@@ -1,4 +1,5 @@
 import click
+
 from redash_toolbelt import Redash
 
 
@@ -11,7 +12,8 @@ class Lookup(object):
         if not query_result_id:
             return False
 
-        result = self.redash._get("api/query_results/{}".format(query_result_id))
+        result = self.redash._get(
+            "api/query_results/{}".format(query_result_id))
 
         return self.email in result.text.lower()
 
@@ -25,7 +27,8 @@ class Lookup(object):
             if self.email in (tag or "").lower():
                 found_in_query = True
 
-        found_in_result = self.check_query_result(query["latest_query_data_id"])
+        found_in_result = self.check_query_result(
+            query["latest_query_data_id"])
 
         return found_in_query or found_in_result
 
@@ -43,14 +46,14 @@ class Lookup(object):
                 found_in_dashboard = True
 
         if not found_in_dashboard:
-            dash_widgets = self.redash._get(
-                "api/dashboards/{}".format(dashboard["slug"])
-            ).json()["widgets"]
+            dash_widgets = self.redash._get("api/dashboards/{}".format(
+                dashboard["slug"])).json()["widgets"]
 
             # Check text widgets
             if not isinstance(dash_widgets, type(None)):
                 for widget in dash_widgets:
-                    if "visualization" not in widget and self.email in widget["text"]:
+                    if "visualization" not in widget and self.email in widget[
+                            "text"]:
                         found_in_widget = True
 
         return found_in_dashboard or found_in_widget
@@ -62,7 +65,8 @@ class Lookup(object):
             found_q = [query for query in bar if self.check_query(query)]
 
         for query in found_q:
-            query_url = "{}/queries/{}".format(self.redash.redash_url, query["id"])
+            query_url = "{}/queries/{}".format(self.redash.redash_url,
+                                               query["id"])
             print(query_url)
 
         dashboards = self.redash.paginate(self.redash.dashboards)
@@ -71,7 +75,8 @@ class Lookup(object):
             found_d = [dash for dash in bar if self.check_dashboard(dash)]
 
         for dash in found_d:
-            dash_url = "{}/dashboards/{}".format(self.redash.redash_url, dash["slug"])
+            dash_url = "{}/dashboards/{}".format(self.redash.redash_url,
+                                                 dash["slug"])
             print(dash_url)
 
 

--- a/redash_toolbelt/examples/gdpr_scrub.py
+++ b/redash_toolbelt/examples/gdpr_scrub.py
@@ -1,0 +1,98 @@
+import click
+from redash_toolbelt import Redash
+
+
+class Lookup(object):
+    def __init__(self, redash, email):
+        self.email = email.lower()
+        self.redash = redash
+
+    def check_query_result(self, query_result_id):
+        if not query_result_id:
+            return False
+
+        result = self.redash._get("api/query_results/{}".format(query_result_id))
+
+        return self.email in result.text.lower()
+
+    def check_query(self, query):
+        found_in_query = False
+        for field in ("query", "name", "description"):
+            if self.email in (query[field] or "").lower():
+                found_in_query = True
+
+        for tag in query["tags"]:
+            if self.email in (tag or "").lower():
+                found_in_query = True
+
+        found_in_result = self.check_query_result(query["latest_query_data_id"])
+
+        return found_in_query or found_in_result
+
+    def check_dashboard(self, dashboard):
+
+        found_in_dashboard = False
+        found_in_widget = False
+
+        for field in ("slug", "name"):
+            if self.email in (dashboard[field] or "").lower():
+                found_in_dashboard = True
+
+        for tag in dashboard["tags"]:
+            if self.email in (tag or "").lower():
+                found_in_dashboard = True
+
+        if not found_in_dashboard:
+            dash_widgets = self.redash._get(
+                "api/dashboards/{}".format(dashboard["slug"])
+            ).json()["widgets"]
+
+            # Check text widgets
+            if not isinstance(dash_widgets, type(None)):
+                for widget in dash_widgets:
+                    if "visualization" not in widget and self.email in widget["text"]:
+                        found_in_widget = True
+
+        return found_in_dashboard or found_in_widget
+
+    def lookup(self):
+        queries = self.redash.paginate(self.redash.queries)
+
+        with click.progressbar(queries, label="Queries") as bar:
+            found_q = [query for query in bar if self.check_query(query)]
+
+        for query in found_q:
+            query_url = "{}/queries/{}".format(self.redash.redash_url, query["id"])
+            print(query_url)
+
+        dashboards = self.redash.paginate(self.redash.dashboards)
+
+        with click.progressbar(dashboards, label="Dashboards") as bar:
+            found_d = [dash for dash in bar if self.check_dashboard(dash)]
+
+        for dash in found_d:
+            dash_url = "{}/dashboards/{}".format(self.redash.redash_url, dash["slug"])
+            print(dash_url)
+
+
+@click.command()
+@click.argument("redash_host")
+@click.argument("email")
+@click.option(
+    "--api-key",
+    "api_key",
+    envvar="REDASH_API_KEY",
+    show_envvar=True,
+    prompt="API Key",
+    help="User API Key",
+)
+def lookup(redash_host, email, api_key):
+    """Search for EMAIL in queries and query results, output query URL if found."""
+
+    redash = Redash(redash_host, api_key)
+    lookup = Lookup(redash, email)
+    lookup.lookup()
+
+
+if __name__ == "__main__":
+    lookup()


### PR DESCRIPTION
## What kind of PR is this
- [x] Add a script

## Description

Adds [this gist](https://gist.github.com/susodapop/393cc3001519326f987f386da305ae7f) to the `examples` directory. It includes `console_script` that you can call like so:

```bash
$ gdpr-scrub "redash.example.com" "user@example.com" --api-key "abc123"
```

or you can call it directly:

```bash
$ python -m redash_toolbelt.examples.gdpr_scrub "redash.example.com" "user@example.com" --api-key "abc123"
```
## Related Tickets & Documents

~Closes~ Furthers #2 (will still need to be deployed before we can close)

The console script specification can be found at [PyPA](https://packaging.python.org/specifications/entry-points/).

The `pyproject.toml` spec for Poetry is [here](https://python-poetry.org/docs/cli/#run).

