### PR TITLE
Add migration script to examples

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4,49 +4,68 @@ description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
 python-versions = "*"
-version = "2019.11.28"
+version = "2021.5.30"
 
 [[package]]
 category = "main"
-description = "Universal encoding detector for Python 2 and 3"
-name = "chardet"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+marker = "python_version >= \"3\""
+name = "charset-normalizer"
 optional = false
-python-versions = "*"
-version = "3.0.4"
+python-versions = ">=3.5.0"
+version = "2.0.4"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
+category = "main"
+description = "Composable command line interface toolkit"
+name = "click"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.2"
 
 [[package]]
 category = "main"
 description = "Internationalized Domain Names in Applications (IDNA)"
+marker = "python_version >= \"3\""
 name = "idna"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.8"
+python-versions = ">=3.5"
+version = "3.2"
 
 [[package]]
 category = "main"
 description = "Python HTTP for Humans."
 name = "requests"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.22.0"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+version = "2.26.0"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-chardet = ">=3.0.2,<3.1.0"
-idna = ">=2.5,<2.9"
-urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.dependencies.charset-normalizer]
+python = ">=3"
+version = ">=2.0.0,<2.1.0"
+
+[package.dependencies.idna]
+python = ">=3"
+version = ">=2.5,<4"
 
 [package.extras]
-security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 category = "main"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4"
-version = "1.25.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "1.26.6"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
@@ -54,27 +73,31 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [metadata]
-content-hash = "4d17f9e80f90dd84c09b8f46829319f9ba04c4a24359b783035c9f15e84a8115"
+content-hash = "ff8c4753e374f6e419543e3a353afebd63431046b5f9f9b58a6d20ad840de34e"
 python-versions = "^3.6"
 
 [metadata.files]
 certifi = [
-    {file = "certifi-2019.11.28-py2.py3-none-any.whl", hash = "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3"},
-    {file = "certifi-2019.11.28.tar.gz", hash = "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"},
+    {file = "certifi-2021.5.30-py2.py3-none-any.whl", hash = "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"},
+    {file = "certifi-2021.5.30.tar.gz", hash = "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee"},
 ]
-chardet = [
-    {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
-    {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.4.tar.gz", hash = "sha256:f23667ebe1084be45f6ae0538e4a5a865206544097e4e8bbcacf42cd02a348f3"},
+    {file = "charset_normalizer-2.0.4-py3-none-any.whl", hash = "sha256:0c8911edd15d19223366a194a513099a302055a962bca2cec0f54b8b63175d8b"},
+]
+click = [
+    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
+    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
 ]
 idna = [
-    {file = "idna-2.8-py2.py3-none-any.whl", hash = "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"},
-    {file = "idna-2.8.tar.gz", hash = "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407"},
+    {file = "idna-3.2-py3-none-any.whl", hash = "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a"},
+    {file = "idna-3.2.tar.gz", hash = "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"},
 ]
 requests = [
-    {file = "requests-2.22.0-py2.py3-none-any.whl", hash = "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"},
-    {file = "requests-2.22.0.tar.gz", hash = "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4"},
+    {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
+    {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
 ]
 urllib3 = [
-    {file = "urllib3-1.25.7-py2.py3-none-any.whl", hash = "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293"},
-    {file = "urllib3-1.25.7.tar.gz", hash = "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"},
+    {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
+    {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redash_toolbelt"
-version = "0.1.4"
+version = "0.1.5"
 description = "Redash API client and tools to manage your instance."
 authors = ["Redash Maintainers"]
 license = "BSD-2-Clause"
@@ -21,6 +21,7 @@ gdpr-scrub = "redash_toolbelt.examples.gdpr_scrub:lookup"
 find-tables = "redash_toolbelt.examples.find_table_names:main"
 clone-dashboard-and-queries = "redash_toolbelt.examples.clone_dashboard_and_queries:main"
 export-queries = "redash_toolbelt.examples.query_export:main"
+redash-migrate = "redash_toolbelt.examples.migrate:main"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/redash_toolbelt/examples/migrate.py
+++ b/redash_toolbelt/examples/migrate.py
@@ -1,0 +1,587 @@
+"""
+Author: Jesse Whitehouse
+Last updated: 18 August 2021
+Notes:
+  Copied from https://gist.github.com/arikfr/2c7d09f6837b256c58a3d3ef6a97f61a
+"""
+
+
+import sys, os, json, logging
+import click
+from redash_toolbelt import Redash
+
+logging.basicConfig(stream=sys.stdout, level=logging.ERROR)
+logging.getLogger("requests").setLevel("ERROR")
+
+
+#      ____                                          _
+#     / ___|___  _ __ ___  _ __ ___   __ _ _ __   __| |___
+#    | |   / _ \| '_ ` _ \| '_ ` _ \ / _` | '_ \ / _` / __|
+#    | |__| (_) | | | | | | | | | | | (_| | | | | (_| \__ \
+#     \____\___/|_| |_| |_|_| |_| |_|\__,_|_| |_|\__,_|___/
+
+
+class UserNotFoundException(Exception):
+    pass
+
+
+def check_data_sources(orig_client, dest_client):
+    """Checks for obvious issues with the data source map that can cause issues further on
+    """
+    if len(DATA_SOURCES) == 0 or (
+        len(DATA_SOURCES) == 1 and DATA_SOURCES.get(-1) == -1234
+    ):
+        print("\n\nYou have not set up the data source map in meta.json")
+        print("\n\nCheck complete: ERROR")
+        return
+
+    orig_data_sources = orig_client.get_data_sources()
+
+    print(
+        "\n\nYou have entered {} data sources into meta.json. Your source instance contains {} data sources.".format(
+            len(DATA_SOURCES), len(orig_data_sources)
+        )
+    )
+    if len(DATA_SOURCES) < len(orig_data_sources):
+        print(
+            "Any queries against data sources not specified in meta.json will fail to import"
+        )
+
+    print("\n")
+    has_error = False
+    for ds in orig_data_sources:
+        if ds["id"] not in DATA_SOURCES:
+            print(
+                "WARNING: origin data source {} does not appear in meta.json".format(
+                    ds["id"]
+                )
+            )
+            has_error = True
+
+    dest_data_sources = dest_client.get_data_sources()
+    dest_ds_map = {i["id"]: i for i in dest_data_sources}
+
+    for ds in orig_data_sources:
+        dest_id = DATA_SOURCES.get(ds["id"])
+        this_ds = dest_ds_map.get(dest_id)
+
+        if dest_id is not None:
+            if this_ds is None:
+                print(
+                    "WARNING: origin data source {} appears in meta.json but does not exist in the destination instance".format(
+                        ds["id"]
+                    )
+                )
+                has_error = True
+                continue
+
+            elif this_ds["type"] != ds["type"]:
+                print(
+                    "\n\nWARNING: origin data source {} is of type, destination data source {} is of type {}".format(
+                        ds["id"], ds["type"], this_ds["id"], this_ds["type"]
+                    )
+                )
+                continue
+
+    if has_error:
+        print("\n\nCheck complete: WARNING")
+    else:
+        print("\n\nCheck complete. OK")
+
+
+def import_users(orig_client, dest_client):
+    """This function expects that the meta object already includes details for admin users on the DEST instance.
+    If you already created users on the DEST instance, enter their details into meta before using this function.
+    """
+
+    print("Importing users...")
+
+    def user_lists_are_equal(orig_list, dest_list):
+
+        dest_user_emails = set([i["email"] for i in dest_list])
+        orig_user_emails = set([i["email"] for i in orig_list])
+
+        return dest_user_emails == orig_user_emails
+
+    orig_users = orig_client.paginate(orig_client.users)
+    dest_users = dest_client.paginate(dest_client.users)
+
+    # Check if the user list has already been synced between orig, dest, and meta
+    if valid_user_meta(dest_users):
+        print("OK: users have been synced. Okay to proceed.")
+        return
+
+    # Check if the user list has been synced between orig and dest
+    # In this case, meta.json should be updated
+    if user_lists_are_equal(orig_users, dest_users):
+        print(
+            "CAUTION: orig and dest user lists are in sync, but users are missing from meta.json"
+        )
+        return
+
+    # Users are missing from dest and meta (default case)
+    # Add these users to the dest instance and add them to meta.json
+    for user in orig_users:
+        print("   importing: {}".format(user["id"]))
+        data = {"name": user["name"], "email": user["email"]}
+
+        if user["id"] in meta["users"]:
+            print("    ... skipping: exists.")
+            continue
+
+        if user["email"] == "admin":
+            print("    ... skipping: admin.")
+            continue
+
+        try:
+            response = dest_client._post(f"api/users?no_invite=1", json=data)
+        except Exception as e:
+            print(
+                "Could not create user: probably this user already exists but is not present in meta.json"
+            )
+            continue
+
+        new_user = response.json()
+        meta["users"][user["id"]] = {
+            "id": new_user["id"],
+            "email": new_user["email"],
+            "invite_link": PRESERVE_INVITE_LINKS and new_user["invite_link"] or "",
+        }
+
+    dest_users = dest_client.paginate(dest_client.users)
+    dest_user_emails = [i["email"] for i in dest_users]
+    org_user_emails = [i["email"] for i in orig_users]
+
+    if set(dest_user_emails) == set(org_user_emails):
+        print("User list is now synced!")
+    else:
+        print(
+            "CAUTION: user list is not in sync! Destination contains {} users. Origin contains {} users".format(
+                len(dest_user_emails), len(org_user_emails)
+            )
+        )
+
+
+def import_queries(orig_client, dest_client):
+    print("Import queries...")
+
+    queries = orig_client.paginate(orig_client.queries)
+
+    for query in queries:
+
+        origin_id = query["id"]
+
+        data_source_id = DATA_SOURCES.get(query["data_source_id"])
+
+        if origin_id in meta["queries"] or str(origin_id) in meta["queries"]:
+            print("Query {} - SKIP - was already imported".format(origin_id))
+            continue
+
+        if data_source_id is None:
+            print(
+                "Query {} - SKIP - data source has not been mapped ({})".format(
+                    origin_id, query["data_source_id"]
+                )
+            )
+            continue
+
+        data = {
+            "data_source_id": data_source_id,
+            "query": query["query"],
+            "is_archived": query["is_archived"],
+            "schedule": convert_schedule(query["schedule"]),
+            "description": query["description"],
+            "name": query["name"],
+            "options": query["options"],
+        }
+
+        try:
+            user_api_key = user_with_api_key(query["user"]["id"], dest_client)[
+                "api_key"
+            ]
+        except UserNotFoundException as e:
+            print("Query {} - FAIL - {}".format(query["id"], e))
+            continue
+
+        print("Query {} - OK  - importing".format(origin_id))
+
+        user_client = Redash(DESTINATION, user_api_key)
+
+        try:
+            response = user_client.create_query(data)
+        except Exception as e:
+            print("Query {} - FAIL - {}".format(origin_id, e))
+            continue
+
+        destination_id = response.json()["id"]
+        meta["queries"][query["id"]] = destination_id
+
+        # New queries are always saved as drafts.
+        # Need to sync the ORIGIN draft status to DESTINATION.
+        if not query["is_draft"]:
+            response = dest_client.update_query(destination_id, {"is_draft": False})
+
+    fix_queries(orig_client, dest_client)
+
+
+def fix_queries(orig_client, dest_client):
+    """
+    This runs after importing all queries, so we can update the query id reference
+    in parameter definitions.
+    """
+    print("Updating queries options...")
+
+    for query_id, new_query_id in meta["queries"].items():
+        query = orig_client.get_query(query_id)
+        orig_user_id = query["user"]["id"]
+
+        dest_user_id = meta["users"].get(orig_user_id).get("id")
+
+        print("   Fixing: {}".format(query_id))
+
+        options = query["options"]
+        for p in options.get("parameters", []):
+            if "queryId" in p:
+                p["queryId"] = meta["queries"].get(str(p["queryId"]))
+
+        user_api_key = user_with_api_key(orig_user_id, dest_client,)["api_key"]
+        user_client = Redash(dest_client.redash_url, user_api_key)
+        user_client.update_query(new_query_id, {"options": options})
+
+
+def import_visualizations(orig_client, dest_client):
+    print("Importing visualizations...")
+
+    for query_id, new_query_id in meta["queries"].items():
+
+        if meta.get("flags", {}).get("viz_import_complete", {}).get(query_id):
+            print(
+                "Query {} - SKIP - All visualisations already imported".format(query_id)
+            )
+            continue
+
+        query = orig_client.get_query(query_id)
+
+        orig_user_id = query["user"]["id"]
+
+        try:
+            dest_user_api_key = user_with_api_key(orig_user_id, dest_client)["api_key"]
+        except UserNotFoundException as e:
+            print("Query {} - FAIL - Visualizations skipped: ".format(query_id, e))
+            continue
+
+        print("   importing visualizations of: {}".format(query_id))
+
+        for v in query["visualizations"]:
+
+            if str(v["id"]) in meta["visualizations"]:
+                print("Viz {} - SKIP - Already imported".format(v["id"]))
+                continue
+
+            if v["type"] == "TABLE":
+                response = dest_client.get_query(new_query_id)
+
+                new_vis = response["visualizations"]
+                for new_v in new_vis:
+                    if new_v["type"] == "TABLE":
+                        meta["visualizations"][v["id"]] = new_v["id"]
+            else:
+                user_client = Redash(DESTINATION, dest_user_api_key)
+
+                data = {
+                    "name": v["name"],
+                    "description": v["description"],
+                    "options": v["options"],
+                    "type": v["type"],
+                    "query_id": new_query_id,
+                }
+                response = user_client._post("api/visualizations", json=data)
+
+                meta["visualizations"][v["id"]] = response.json()["id"]
+
+        meta["flags"]["viz_import_complete"][query_id] = True
+
+
+def import_dashboards(orig_client, dest_client):
+    print("Importing dashboards...")
+
+    dashboards = orig_client.paginate(orig_client.dashboards)
+
+    for dashboard in dashboards:
+        if dashboard["slug"] in meta["dashboards"]:
+            print("Dashboard `{}` - SKIP - Already imported".format(dashboard["slug"]))
+            continue
+
+        print("   importing: {}".format(dashboard["slug"]))
+
+        d = orig_client.dashboard(dashboard["slug"])
+
+        orig_user_id = d["user"]["id"]
+
+        try:
+            user_api_key = user_with_api_key(orig_user_id, dest_client,)["api_key"]
+        except UserNotFoundException as e:
+            print("Dashboard {} - FAIL - {}".format(d["slug"], e))
+            continue
+
+        user_client = Redash(DESTINATION, user_api_key)
+
+        new_dashboard = user_client.create_dashboard(d["name"])
+
+        new_dash_id = new_dashboard["id"]
+
+        # Sets published status to match source instance
+        not d["is_draft"] and user_client.update_dashboard(
+            new_dash_id, {"is_draft": False}
+        )
+
+        # recreate widget
+        for widget in d["widgets"]:
+            data = {
+                "dashboard_id": new_dash_id,
+                "options": widget["options"] or {},
+                "width": widget["width"],
+                "text": widget["text"],
+                "visualization_id": None,
+            }
+
+            if "visualization" in widget:
+                data["visualization_id"] = meta["visualizations"].get(
+                    str(widget["visualization"]["id"])
+                )
+
+            if "visualization" in widget and not data["visualization_id"]:
+                print(
+                    "Widget {} - SKIP - visualization is missing (check missing data source, query, or viz)".format(
+                        widget["id"]
+                    )
+                )
+                continue
+
+            user_client.create_widget(
+                new_dash_id, data["visualization_id"], data["text"], data["options"]
+            )
+
+        meta["dashboards"].update({d["slug"]: new_dashboard["slug"]})
+
+
+#     _   _ _   _ _ _ _   _
+#    | | | | |_(_) (_) |_(_) ___  ___
+#    | | | | __| | | | __| |/ _ \/ __|
+#    | |_| | |_| | | | |_| |  __/\__ \
+#     \___/ \__|_|_|_|\__|_|\___||___/
+
+
+def valid_user_meta(dest_users):
+    """Confirms all users in DEST are present in meta."""
+
+    meta_user_list = [i["email"] for i in meta["users"].values()]
+
+    missing = []
+    for usr in dest_users:
+        email = usr["email"]
+        if email in meta_user_list:
+            continue
+        else:
+            missing.append(email)
+
+    if len(missing) == 0:
+        print("OK: Meta agrees with dest user list")
+        return True
+    else:
+        print("CAUTION: Some users are missing from the meta.json. ")
+        [print(i) for i in missing]
+        return False
+
+
+def user_with_api_key(origin_user_id, dest_client):
+    """Look up the destination user object using its origin user ID.
+
+    The destination client must be an admin to have access to the user API key.
+    """
+    user = meta["users"].get(origin_user_id)
+
+    if user is None:
+        raise UserNotFoundException(
+            "Origin user: {} not found in meta.json. Was this user disabled?".format(
+                origin_user_id
+            )
+        )
+    if "api_key" not in user:
+        user["api_key"] = get_api_key(dest_client, user["id"])
+    return user
+
+
+def convert_schedule(schedule):
+    if schedule is None:
+        return schedule
+
+    if isinstance(schedule, dict):
+        return schedule
+
+    schedule_json = {"interval": None, "until": None, "day_of_week": None, "time": None}
+
+    if ":" in schedule:
+        schedule_json["interval"] = 86400
+        schedule_json["time"] = schedule
+    else:
+        schedule_json["interval"] = schedule
+
+    return schedule_json
+
+
+def get_api_key(client, user_id):
+    response = client._get(f"api/users/{user_id}")
+
+    return response.json()["api_key"]
+
+
+#
+#          __  __      _
+#         |  \/  | ___| |_ __ _
+#         | |\/| |/ _ \ __/ _` |
+#         | |  | |  __/ || (_| |
+#         |_|  |_|\___|\__\__,_|
+#
+
+
+# include here any users you already created in the target Redash account.
+# the key is the user id in the origin Redash instance.
+base_meta = {
+    "users": {"-1": {"id": -1, "email": "",}},
+    "queries": {},
+    "visualizations": {},
+    "dashboards": {},
+    "flags": {"viz_import_complete": {}},
+    "data_sources": {"-1": -1234},
+    "settings": {
+        "origin_url": "",
+        "origin_admin_api_key": "",
+        "destination_url": "",
+        "destination_admin_api_key": "",
+        "preserve_invite_links": True,
+    },
+}
+
+
+def init():
+    """Create a meta.json file"""
+    if not os.path.exists("meta.json"):
+        with open("meta.json", "w") as fp:
+            json.dump(base_meta, fp, indent=4)
+    else:
+        print("meta.json file already exists!")
+
+
+def get_meta(tries=0):
+
+    if tries > 1:
+        raise Exception("Could not create or read meta.json")
+        
+    try:
+        with open("meta.json", "r") as fp:
+            return json.load(fp)
+    except FileNotFoundError:
+        print("meta.json not found...creating...try again")
+        init()
+        return get_meta(tries+1)
+    except json.JSONDecodeError:
+        raise Exception("badly formed meta.json...please delete and try again")
+
+
+def save_meta():
+    print("Saving meta...")
+    with open("meta.json", "w") as f:
+        json.dump(meta, f, indent=4)
+
+
+def save_meta_wrapper(func):
+    def wrapped(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except Exception as e:
+            print(e)
+        finally:
+            save_meta()
+
+    return wrapped
+
+
+#      ____ _     ___
+#     / ___| |   |_ _|
+#    | |   | |    | |
+#    | |___| |___ | |
+#     \____|_____|___|
+
+
+try:
+    meta = get_meta()
+    meta["users"] = {int(key): val for key, val in meta["users"].items()}
+    meta["data_sources"] = {int(key): val for key, val in meta["data_sources"].items()}
+
+    # The Redash instance you're copying from:
+    ORIGIN = meta["settings"]["origin_url"]
+    ORIGIN_API_KEY = meta["settings"]["origin_admin_api_key"]
+
+    # The Redash account you're copying into:
+    DESTINATION = meta["settings"]["destination_url"]
+    DESTINATION_API_KEY = meta["settings"]["destination_admin_api_key"]
+
+    PRESERVE_INVITE_LINKS = meta["settings"]["preserve_invite_links"]
+
+    DATA_SOURCES = meta["data_sources"]
+except Exception as e:
+    print(
+        "Script failed during initialization."
+    )
+    print("Exception: {}".format(e))
+
+
+@click.command()
+@click.argument("command",)
+def main(command):
+    """Redash migration command. Can be used to migrate objects (queries, visualizations, dashboards)
+    from one Redash instance to another.
+
+    Usage: python migrate.py <COMMAND>
+
+    Available commands are: 
+    
+    check_data_sources: compare the data sources written to meta.json against those visible on origin and destination Redash instances
+    
+    users: migrate users
+    
+    queries: migrate queries and then fix any query-based dropdown list parameter references. Skips queries from users not in meta.json
+    
+    visualizations: migrate visualizations for queries that successfully migrated
+    
+    dashboards: migrate dashboards. skips widgets with missing visualizations or users
+
+    These should be called in that order. Checking the contents of meta.json between steps to confirm
+    expected behavior.
+    """
+    if command == "init":
+        print("meta.json initialized")
+        return
+
+    from_client = Redash(ORIGIN, ORIGIN_API_KEY)
+    to_client = Redash(DESTINATION, DESTINATION_API_KEY)
+
+    command_map = {
+        "check_data_sources": check_data_sources,
+        "users": import_users,
+        "queries": import_queries,
+        "visualizations": import_visualizations,
+        "dashboards": import_dashboards,
+    }
+
+    this_command = save_meta_wrapper(command_map.get(command))
+
+    if this_command is None:
+        print("No command provided. See --help for instructions")
+
+    this_command(from_client, to_client)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## ⚠️ Warning! This is a work in progress! ⚠️ 
This script is still being developed with completion targeted for the end of August 2021. This warning will be removed and replaced with usage instructions once the work is complete.

## Type of PR

- [x] Add a script

## Description

This effort will add a revised version of [this gist](https://gist.github.com/arikfr/2c7d09f6837b256c58a3d3ef6a97f61a) that uses the `redash_toolbelt` client, supports recent versions of Redash and migrates all of the content (the gist was skipping alerts and favorites).

## Steps

- [x] Convert to Python3 with `2to3`
- [x] Refactor to use `client.py`
- [ ] Add support for migrating alerts
- [ ] Add support for migrating favorites
- [ ] Add a "dry run" / "read only" option
- [ ] Add unit tests
- [ ] Add script entry point to `pyproject.toml`
- [ ] Publish documentation / examples

## Related Tickets & Documents

#5