### PR TITLE
Fix format_query when query terminated with a semicolon.

### DIFF
--- a/redash_toolbelt/examples/find_table_names.py
+++ b/redash_toolbelt/examples/find_table_names.py
@@ -41,7 +41,7 @@ def format_query(str_sql):
     """Strips all newlines, excess whitespace, and spaces around commas"""
 
     stage1 = str_sql.replace("\n", " ")
-    stage2 = re.sub(r"\s+", " ", stage1).strip()
+    stage2 = re.sub(r"\s+", " ", stage1).strip().rstrip(";")
     stage3 = re.sub(r"(\s*,\s*)", ",", stage2)
 
     return stage3
@@ -264,5 +264,15 @@ def test_9():
 
     tables = extract_table_names(sql)
     expected = ["table1", "table2", "table3", "table4", "table5"]
+
+    assert len(tables) == len(expected) and all([i in expected for i in tables])
+
+
+def test_10():
+
+    sql = "SELECT field FROM table1;"
+
+    tables = extract_table_names(sql)
+    expected = ["table1"]
 
     assert len(tables) == len(expected) and all([i in expected for i in tables])

--- a/redash_toolbelt/examples/find_table_names.py
+++ b/redash_toolbelt/examples/find_table_names.py
@@ -121,8 +121,8 @@ def print_details(tables_by_qry):
 
 
 @click.command()
-@click.argument("url",)
-@click.argument("key",)
+@click.argument("url")
+@click.argument("key")
 @click.argument("data_source_id")
 @click.option("--detail", is_flag=True, help="Prints out all table/query pairs?")
 def main(url, key, data_source_id, detail):


### PR DESCRIPTION
# Problem

When I have some queries terminated with a semicolon, then `find-tables` fails.
(i.e. `SELECT * FROM table;`)

# Solution

Trim semicolon from queries before extract table names.