### PR TITLE
Adds functionality to pull data_sources

### DIFF
--- a/redash_toolbelt/client.py
+++ b/redash_toolbelt/client.py
@@ -117,7 +117,7 @@ class Redash(object):
         return self._request("POST", path, **kwargs)
 
     def _request(self, method, path, **kwargs):
-        url = "{}/{}".format(self.redash_url, path)
+        url = "{}/{}".format(self.redash_url.rstrip("/"), path.lstrip("/"))
         response = self.session.request(method, url, **kwargs)
         response.raise_for_status()
         return response

--- a/redash_toolbelt/client.py
+++ b/redash_toolbelt/client.py
@@ -30,6 +30,12 @@ class Redash(object):
         """GET api/dashboards/{slug}"""
         return self._get("api/dashboards/{}".format(slug)).json()
 
+    def data_sources(self, page=1, page_size=25):
+        """GET api/data_sources"""
+        return self._get(
+            "api/data_sources", params=dict(page=page, page_size=page_size)
+        ).json()
+
     def create_dashboard(self, name):
         return self._post("api/dashboards", json={"name": name}).json()
 


### PR DESCRIPTION
This allows both the abilitiy to pull data sources because you need this to figure out the ID of datasets to use the migration script. Also, I added in so it strips the '/' from the right and left of each side before combining URLs, so it is always a valid URL. This was a problem in the migrate script, where this wasn't consistent and was calling these functions. This is an internal class, so maybe you don't want this change, and I can remove it.