### PR TITLE
Do not import favorites for disabled users

### DIFF
--- a/redash_toolbelt/examples/migrate.py
+++ b/redash_toolbelt/examples/migrate.py
@@ -152,7 +152,7 @@ def import_users(orig_client, dest_client):
             "id": new_user["id"],
             "email": new_user["email"],
             "invite_link": PRESERVE_INVITE_LINKS and new_user["invite_link"] or "",
-            "disabled": user["is_disabled"],
+            "disabled": False,
         }
 
     dest_users = dest_client.paginate(dest_client.users)

--- a/redash_toolbelt/examples/migrate.py
+++ b/redash_toolbelt/examples/migrate.py
@@ -152,7 +152,7 @@ def import_users(orig_client, dest_client):
             "id": new_user["id"],
             "email": new_user["email"],
             "invite_link": PRESERVE_INVITE_LINKS and new_user["invite_link"] or "",
-            "disabled": False,
+            "disabled": user["is_disabled"],
         }
 
     dest_users = dest_client.paginate(dest_client.users)

--- a/redash_toolbelt/examples/migrate.py
+++ b/redash_toolbelt/examples/migrate.py
@@ -490,10 +490,17 @@ def import_favorites(orig_client, dest_client):
 
     for orig_id, data in meta["users"].items():
 
+        user_dest = user_with_api_key(orig_id, dest_client)
+        user_dest_api_key = user_dest['api_key']
         user_orig_api_key = get_api_key(orig_client, orig_id)
+
+        if "disabled" in data and data["disabled"]:
+            print(f"User {user_dest['email']} is disabled. Skipping import.")
+            continue
+
         orig_user_client = Redash(ORIGIN, user_orig_api_key)
         dest_user_client = Redash(
-            DESTINATION, user_with_api_key(orig_id, dest_client)["api_key"]
+            DESTINATION, user_dest_api_key
         )
 
         favorite_queries = orig_user_client.paginate(


### PR DESCRIPTION
At the moment import_favorites fails if there are ANY disabled users on the origin.

If we perform /api/queries/favorites for a disabled user, we get a 404, which causes https://github.com/getredash/redash-toolbelt/blob/24f1f9b5a1a4f0edea6f3a17df92910af7b1e4a3/redash_toolbelt/client.py#L199 to blow up and stop importing any favorites.

This PR checks if the user is disabled before performing any queries, and if the user is disabled, the import_favorites does not execute