### PR TITLE
Bump version to .6 and fix bad TOML syntax.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [tool.poetry]
 name = "redash_toolbelt"
-version = "0.1.5"
+version = "0.1.6"
 description = "Redash API client and tools to manage your instance."
 authors = ["Redash Maintainers"]
 license = "BSD-2-Clause"
 homepage = "https://github.com/getredash/redash-toolbelt"
-repository = ""https://github.com/getredash/redash-toolbelt"
+repository = "https://github.com/getredash/redash-toolbelt"
 readme = "README.md"
 
 packages = [


### PR DESCRIPTION
Growing pains here 😓 

I couldn't deploy the changes in #67 for two reasons:
1. There was a doubled quotation mark in `pyproject.toml`
2. Pypi doesn't allow us to overwrite a version in the index

This PR fixes the missing quotation mark and bumps the version to `0.1.6`.