### PR TITLE
Fix visualizations command in redash-migrate

### DIFF
--- a/redash_toolbelt/examples/migrate.py
+++ b/redash_toolbelt/examples/migrate.py
@@ -497,7 +497,7 @@ def import_visualizations(orig_client, dest_client):
 
     for query_id, new_query_id in meta["queries"].items():
 
-        if meta.get("flags", {}).get("viz_import_complete", {}).get(query_id):
+        if meta.get("flags", {}).get("viz_import_complete", {}).get(str(query_id)):
             print(
                 "Query {} - SKIP - All visualisations already imported".format(query_id)
             )
@@ -542,7 +542,7 @@ def import_visualizations(orig_client, dest_client):
 
                 meta["visualizations"][v["id"]] = response.json()["id"]
 
-        meta["flags"]["viz_import_complete"][query_id] = True
+        meta["flags"]["viz_import_complete"][str(query_id)] = True
 
 
 def import_dashboards(orig_client, dest_client):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Bug Fix

## Description

It will fix a bug in `visualizations` command in `redash-migrate`.

## Steps to reproduce the bug

Running `redash-migrate visualizations` twice will break meta.json.

first time,

```json
{
...snip...
    "visualizations": {
        "3": 4,
        "4": 5,
        "5": 7
    },
    "dashboards": {},
    "alerts": {},
    "flags": {
        "viz_import_complete": {
            "3": true,
            "4": true
        }
    },
...snip...
```

then, run again,

```json
{
...snip...
    "visualizations": {
        "3": 4,
        "4": 5,
        "5": 7
    },
    "dashboards": {},
    "alerts": {},
    "flags": {
        "viz_import_complete": {
            "3": true,
            "4": true,
            "3": true, <- existing keys are appeared.
            "4": true
        }
    },
...snip...
```
