### PR TITLE
fix: prevent builtin groups from being duplicated during migration

### DIFF
--- a/redash_toolbelt/client.py
+++ b/redash_toolbelt/client.py
@@ -205,6 +205,9 @@ class Redash(object):
     def _post(self, path, **kwargs):
         return self._request("POST", path, **kwargs)
 
+    def _delete(self, path, **kwargs):
+        return self._request("DELETE", path, **kwargs)
+
     def _request(self, method, path, **kwargs):
         url = "{}/{}".format(self.redash_url, path)
         response = self.session.request(method, url, **kwargs)


### PR DESCRIPTION
Also:

- Restores original data source association for builtin groups
- Allow for a group with no members to retain original data sources