### PR TITLE
Bump to 0.1.7 ahead of forthcoming release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redash_toolbelt"
-version = "0.1.6"
+version = "0.1.7"
 description = "Redash API client and tools to manage your instance."
 authors = ["Redash Maintainers"]
 license = "BSD-2-Clause"


### PR DESCRIPTION
0.1.6 is already released. The repo should stay ahead of the current released version so it's clear that master and the release differ.