### PR TITLE
Update redash-migrate README with details about data source migration.

### DIFF
--- a/redash_toolbelt/docs/redash-migrate/README.md
+++ b/redash_toolbelt/docs/redash-migrate/README.md
@@ -152,7 +152,7 @@ alerts                Duplicate alert definitions from the origin instance to th
                       the `queries` command. Run the `destinations` command first.
 favorites             Duplicate favorite flags on queries and dashboards from the origin
                       instance to the destination instance.
-disable_users         Disable users in the destination instance that are disabled in the
+disable-users         Disable users in the destination instance that are disabled in the
                       origin instance.
 ```
 

--- a/redash_toolbelt/examples/migrate.py
+++ b/redash_toolbelt/examples/migrate.py
@@ -1102,7 +1102,7 @@ def main(command):
                             instance to the destination instance.
 
       \b
-      disable_users         Disable users in the destination instance that are disabled in the
+      disable-users         Disable users in the destination instance that are disabled in the
                             origin instance.
 
       \b
@@ -1137,7 +1137,7 @@ def main(command):
         "dashboards": import_dashboards,
         "alerts": import_alerts,
         "favorites": import_favorites,
-        "disable_users": disable_users,
+        "disable-users": disable_users,
     }
 
     _command = command_map.get(command)


### PR DESCRIPTION
## Description

Two changes in this PR:

1. Update the README with details about the `data_sources` command
2. Rename `data_sources` to `data-sources` so it will be consistent with other CLI tools.

```shell
# before
redash-migrate data_sources

# after
redash-migrate data-sources
```

## Related Tickets & Documents

Resolves confusion around #86 