### PR TITLE
[RT-69] redash-migrate: preserve default table visualization settings

### DIFF
--- a/redash_toolbelt/examples/migrate.py
+++ b/redash_toolbelt/examples/migrate.py
@@ -633,7 +633,7 @@ def import_visualizations(orig_client, dest_client):
 
     for query_id, new_query_id in meta["queries"].items():
 
-        if meta["flags"]["viz_import_complete"][query_id]:
+        if meta["flags"]["viz_import_complete"].get(query_id):
             print(
                 "Query {} - SKIP - All visualisations already imported".format(query_id)
             )
@@ -679,7 +679,7 @@ def import_visualizations(orig_client, dest_client):
             "options": orig_default_table["options"],
         }
 
-        print("Query {} - OK - Updating default table visualization settings")
+        print("Query {} - OK - Updating default table visualization settings".format(dest_query_id))
         user_client.update_visualization(
             dest_default_table["id"], default_table_viz_data
         )

--- a/redash_toolbelt/examples/migrate.py
+++ b/redash_toolbelt/examples/migrate.py
@@ -679,7 +679,11 @@ def import_visualizations(orig_client, dest_client):
             "options": orig_default_table["options"],
         }
 
-        print("Query {} - OK - Updating default table visualization settings".format(dest_query_id))
+        print(
+            "Query {} - OK - Updating default table visualization settings".format(
+                dest_query_id
+            )
+        )
         user_client.update_visualization(
             dest_default_table["id"], default_table_viz_data
         )

--- a/redash_toolbelt/examples/migrate.py
+++ b/redash_toolbelt/examples/migrate.py
@@ -634,19 +634,22 @@ def import_visualizations(orig_client, dest_client):
     for query_id, new_query_id in meta["queries"].items():
 
         if meta["flags"]["viz_import_complete"][query_id]:
-            print("Query {} - SKIP - All visualisations already imported".format(query_id))
+            print(
+                "Query {} - SKIP - All visualisations already imported".format(query_id)
+            )
             # fmt: on
             continue
-
 
         # Gather origin info
         query = orig_client.get_query(query_id)
         orig_user_id = query["user"]["id"]
 
         # Sort both lists to retain visualization order on the query screen
-        orig_table_visualizations = sorted([i for i in query["visualizations"] if i["type"] == "TABLE"], key=lambda x: x["id"])
+        orig_table_visualizations = sorted(
+            [i for i in query["visualizations"] if i["type"] == "TABLE"],
+            key=lambda x: x["id"],
+        )
         orig_default_table = orig_table_visualizations[0]
-
 
         # Build a user client so write operations preserve the original created by...
 
@@ -664,17 +667,22 @@ def import_visualizations(orig_client, dest_client):
         # Sort this table like orig_table_visualizations.
         # The first elements in these lists should mirror
         # one another.
-        dest_table_visualizations = sorted([i for i in dest_query["visualizations"] if i["type"] == "TABLE"], key=lambda x: x["id"])
+        dest_table_visualizations = sorted(
+            [i for i in dest_query["visualizations"] if i["type"] == "TABLE"],
+            key=lambda x: x["id"],
+        )
         dest_default_table = dest_table_visualizations[0]
 
-        default_table_viz_data =  {
-                "name": orig_default_table["name"],
-                "description": orig_default_table["description"],
-                "options": orig_default_table["options"],
-            }
+        default_table_viz_data = {
+            "name": orig_default_table["name"],
+            "description": orig_default_table["description"],
+            "options": orig_default_table["options"],
+        }
 
         print("Query {} - OK - Updating default table visualization settings")
-        user_client.update_visualization(dest_default_table["id"], default_table_viz_data)
+        user_client.update_visualization(
+            dest_default_table["id"], default_table_viz_data
+        )
         meta["visualizations"][orig_default_table["id"]] = dest_default_table["id"]
 
         for v in sorted(query["visualizations"], key=lambda x: x["id"]):
@@ -1189,7 +1197,9 @@ def make_global_meta():
     meta["data_sources"] = cast_keys_to_int(meta["data_sources"])
     meta["groups"] = cast_keys_to_int(meta["groups"])
     meta["destinations"] = cast_keys_to_int(meta["destinations"])
-    meta["flags"]["viz_import_complete"] = cast_keys_to_int(meta["flags"]["viz_import_complete"])
+    meta["flags"]["viz_import_complete"] = cast_keys_to_int(
+        meta["flags"]["viz_import_complete"]
+    )
 
     # The Redash instance you're copying from:
     ORIGIN = meta["settings"]["origin_url"]


### PR DESCRIPTION
Closes #69 
Also implements the same fix as #71 