### PR TITLE
Add additional note about disabling rate limit

### DIFF
--- a/redash_toolbelt/examples/migrate.py
+++ b/redash_toolbelt/examples/migrate.py
@@ -1157,7 +1157,17 @@ def init():
     It's important to provide the correct information here to ensure that all objects are copied
     correctly from the ORIGIN instance to the DESTINATION instance.
 
-    Please note that this script will solicit an email address from you. But NO EMAILS WILL BE SENT.
+    Further important notes:
+
+      * This script will ask for an email address from you.  It's only used for login purposes,
+        and NO EMAILS WILL BE SENT.
+
+      * Please ensure you have turned OFF the rate limiting in your DESTINATION Redash,
+        otherwise the migration can experience problems.  eg not being able to create users,
+        groups, (and other things) in the destination Redash.
+
+        You can disable rate limiting by adding `REDASH_RATELIMIT_ENABLED=false` to your
+        DESTINATION Redash environment (env) file.
     """
     )
 

--- a/redash_toolbelt/examples/migrate.py
+++ b/redash_toolbelt/examples/migrate.py
@@ -1157,17 +1157,8 @@ def init():
     It's important to provide the correct information here to ensure that all objects are copied
     correctly from the ORIGIN instance to the DESTINATION instance.
 
-    Further important notes:
-
-      * This script will ask for an email address from you.  It's only used for login purposes,
-        and NO EMAILS WILL BE SENT.
-
-      * Please ensure you have turned OFF the rate limiting in your DESTINATION Redash,
-        otherwise the migration can experience problems.  eg not being able to create users,
-        groups, (and other things) in the destination Redash.
-
-        You can disable rate limiting by adding `REDASH_RATELIMIT_ENABLED=false` to your
-        DESTINATION Redash environment (env) file.
+    Before proceeding, you should disable the rate limits on your DESTINATION instance. Do this
+    by setting the `REDASH_RATE_LIMIT_ENABLED` environment variable to `false`.
     """
     )
 
@@ -1204,7 +1195,7 @@ def init():
         )
     )
     destination_admin_email_address = input(
-        "Please enter the email address for the destination admin user: "
+        "Please enter the email address for the destination admin user (no emails will be sent): "
     )
 
     meta["settings"]["destination_url"] = destination_url

--- a/redash_toolbelt/examples/migrate.py
+++ b/redash_toolbelt/examples/migrate.py
@@ -1158,7 +1158,8 @@ def init():
     correctly from the ORIGIN instance to the DESTINATION instance.
 
     Before proceeding, you should disable the rate limits on your DESTINATION instance. Do this
-    by setting the `REDASH_RATE_LIMIT_ENABLED` environment variable to `false`.
+    by setting the `REDASH_RATE_LIMIT_ENABLED` environment variable to `false`. After migration
+    you should re-enable the rate limits by setting this variable to `true`.
     """
     )
 


### PR DESCRIPTION
This seems like reasonable wording for an additional warning to disable rate limiting.

Disabling rate limiting before the migration is important, as otherwise the migration
can act strangely and generate errors which aren't obviously rate limit related. eg:
```
  $ redash-toolbelt users
   importing: [redacted]
   importing: [redacted]
Could not create user: probably this user already exists but is not present in meta.json
   importing: [redacted]
Could not create user: probably this user already exists but is not present in meta.json
   importing: [redacted]
Could not create user: probably this user already exists but is not present in meta.json
   importing: [redacted]
```